### PR TITLE
Add v6.0 & dev-master to wordpress-stubs version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/php-stubs/acf-pro-stubs",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6 || dev-master"
+        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "php": "~7.1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/php-stubs/acf-pro-stubs",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0"
+        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6 || dev-master"
     },
     "require-dev": {
         "php": "~7.1",


### PR DESCRIPTION
Added constraints to allow this to be installed alongside the recently updated wordpress-stubs package. Also added dev-master since these are for testing and some people prefer to always have the latest release. 