### PR TITLE
Set license to MIT in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "phpstan"
     ],
     "homepage": "https://github.com/php-stubs/acf-pro-stubs",
-    "license": "GPL-2.0-or-later",
+    "license": "MIT",
     "require": {
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
     },


### PR DESCRIPTION
I noticed the license is GPL in composer.json but the repo LICENSE file says MIT (we're copying this code 🐱‍👤)