### PR TITLE
Download ACF Pro release using Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 /advanced-custom-fields/
+auth.json

--- a/auth.json.example
+++ b/auth.json.example
@@ -1,0 +1,8 @@
+{
+    "http-basic": {
+        "connect.advancedcustomfields.com": {
+            "username": "xyz",
+            "password": "http://your_password"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "homepage": "https://github.com/php-stubs/acf-pro-stubs",
     "license": "MIT",
     "require": {
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+        "wpengine/advanced-custom-fields-pro": "6.3.8"
     },
     "require-dev": {
         "php": "~7.1 || ^8.0",
@@ -21,5 +22,23 @@
         "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
         "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://connect.advancedcustomfields.com"
+        }
+    ],
+    "extra": {
+        "installer-paths": {
+            "source/{$name}/": [
+                "type:wordpress-plugin"
+            ]
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
+    }
 }

--- a/release-latest-versions.sh
+++ b/release-latest-versions.sh
@@ -17,10 +17,6 @@ Get_versions()
 mkdir -p advanced-custom-fields
 
 while read -r VERSION; do
-    ## Process 5.6+ versions only
-    #if dpkg --compare-versions "${VERSION}" lt "5.6.0"; then
-    #    continue
-    #fi
     # Process 6.0+ versions only
     if dpkg --compare-versions "${VERSION}" lt "6.0.0"; then
         continue
@@ -33,25 +29,17 @@ while read -r VERSION; do
         continue
     fi
 
-    # Download release
-    RELEASE="advanced-custom-fields/acf-pro-${VERSION}.zip"
-    wget -nv -O "${RELEASE}" \
-        "https://connect.advancedcustomfields.com/index.php?p=pro&a=download&t=${VERSION}&k=${ACF_PRO_KEY}"
-
-    if [ "$(file --brief --mime "${RELEASE}")" != "application/zip; charset=binary" ]; then
-        echo "Skipping ${VERSION} ..."
-        continue
-    fi
-
-    # Extract release
+    # Clear previous source
     rm -f -r source/advanced-custom-fields-pro
-    unzip -q "${RELEASE}" -d source
+
+    # Download release using Composer
+    composer require wpengine/advanced-custom-fields-pro:${VERSION} --ignore-platform-reqs
 
     # Generate stubs
     echo "Generating stubs ..."
     ./generate.sh
 
     # Tag version
-    git commit --all -m "Generate stubs for ACF PRO ${VERSION}"
+    git commit acf-pro-stubs.php -m "Generate stubs for ACF PRO ${VERSION}"
     git tag "v${VERSION}"
 done < <(Get_versions | tac)


### PR DESCRIPTION
Downloading ACF Pro release using directly via HTTP is obsolete (https://www.advancedcustomfields.com/resources/installing-acf-pro-with-composer/). This PR fixes this by using Composer to download ACF Pro release.
