### PR TITLE
Update wordpress-stubs requirement to include version 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/php-stubs/acf-pro-stubs",
     "license": "MIT",
     "require": {
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "php": "~7.1 || ^8.0",


### PR DESCRIPTION
I use ACF on every site I build, so I can't use the updated 7.0 version of wordpress-stubs and ACF stubs at the same time without this change.